### PR TITLE
Fix "Updating odoo versions in docs" command

### DIFF
--- a/docs/migration/helpers.rst
+++ b/docs/migration/helpers.rst
@@ -39,7 +39,7 @@ Updating odoo versions in docs
 .. code-block:: sh
 
     # bump versions in docs (excluding "Tested on Odoo" expression)
-    find . -type f -name *.rst -or -name *.html | xargs sed -i '/Tested on Odoo/!s/12.0/13.0/g'
+    find . -type f -name *.rst -or -name *.html | xargs sed -i '/Tested on /!s/12.0/13.0/g'
 
 Reviewing odoo updates
 ======================

--- a/docs/migration/helpers.rst
+++ b/docs/migration/helpers.rst
@@ -39,7 +39,7 @@ Updating odoo versions in docs
 .. code-block:: sh
 
     # bump versions in docs (excluding "Tested on Odoo" expression)
-    find . -type f -name *.rst -or -name *.html | xargs sed -i '/Tested on /!s/12.0/13.0/g'
+    find . -type f -name *.rst -or -name *.html -or -name *.md | xargs sed -i '/Tested on /!s/12.0/13.0/g'
 
 Reviewing odoo updates
 ======================


### PR DESCRIPTION
Before this commit, it didn't work for "Tested on XX.Y" expressions