### PR TITLE
WIP : Postgresql command line tool pgcli

### DIFF
--- a/docs/maintenance/database_tool.rst
+++ b/docs/maintenance/database_tool.rst
@@ -1,0 +1,14 @@
+Postgresql command line client
+
+Pgcli is a command line interface for Postgres with auto-completion and syntax highlighting. 
+
+https://github.com/dbcli/pgcli
+https://www.pgcli.com/
+
+Useful tool to check or update database content, with curse graphical browsing, 
+syntax highlighting and auto-completion of SQL commands, tables and fields name.
+
+- Browsable content
+- Auto-completes as you type for SQL keywords as well as tables and columns in the database.
+- Syntax highlighting
+- Smart-completion will suggest context-sensitive completion.


### PR DESCRIPTION
This a work in progress, let me know if it is of some interest.
`pgcli` is a useful curse command line tool for fixing or debugging postgresql problems. 